### PR TITLE
Edit Song, Teleport

### DIFF
--- a/src/props/obj_props.json
+++ b/src/props/obj_props.json
@@ -1042,6 +1042,27 @@
         "P2": ["bool", 200],
         "PT": ["bool", 201]
     },
+    "Teleport Trigger": {
+        "target id": ["int", 51],
+
+        "gravity": ["int ∈ [0, 3]", 354, "no change, normal, flipped, toggle"],
+        "smooth ease": ["bool", 55],
+        "save offset": ["bool", 351],
+        "ignore x": ["bool", 352],
+        "ignore y": ["bool", 453],
+        "instant camera": ["bool", 464],
+        "snap ground": ["bool", 510],
+        "redirect dash": ["bool", 591],
+    
+        "rotate static enable": ["bool", 345],
+        "rotate static force": ["float", 346],
+        "rotate static additive": ["bool", 443],
+    
+        "rotate redirect enable": ["bool", 347],
+        "rotate redirect min": ["float", 348],
+        "rotate redirect max": ["float", 349],
+        "rotate redirect mod": ["float", 350]
+    },
     "Player Control Trigger": {
         "P1": ["bool", 138],
         "P2": ["bool", 200],

--- a/src/props/obj_props.json
+++ b/src/props/obj_props.json
@@ -769,6 +769,33 @@
         "song": ["int", 392]
     },
 
+    "Edit Song Trigger": {
+        "stop": ["bool", 417],
+        "stop loop": ["bool", 414],
+
+        "speed": ["int", 404],
+        "change speed": ["bool", 419],
+        "volume": ["float", 406],
+        "change volume": ["bool", 418],
+
+        "volume near": ["float", 421],
+        "min distance": ["float", 424],
+        "volume med": ["float", 422],
+        "dist 2": ["float", 425],
+        "volume far": ["float", 423],
+        "dist 3": ["float", 426],
+
+        "prox around group": ["int", 51],
+        "prox follow group": ["int", 71],
+
+        "follow player 1": ["bool", 138],
+        "follow player 2": ["bool", 200],
+        "follow camera": ["bool", 428],
+
+        "channel": ["int", 432],
+        "dir buttons": ["int ∈ [0, 6]", 458, "outwards, horizontal both, horizontal left, horizontal right, vertical both, vertical up, vertical down"]
+    },
+
     "Pickup Trigger": {
         "item id": ["int", 80],
         "count": ["int", 77],


### PR DESCRIPTION
Common group names not already in index sourced from SPWN standard library.

## Edit Song

Not sure what `155` is in this, or the next one.
```
reference:
  = 3 (Y) : 105
  = 1 (Object ID) : 3605
  = 2 (X) : 75
  = 155 : 1
  = 421 (VolNear) : 1
  = 406 (Volume) : 1
  = 422 (VolMed) : 0.5
  = 10 (Duration) : 0.5
  = 36 ("Active Trigger") : true
```

Edit song also has the common `duration` property from Trigger Common.

## Teleport

Looks complete. Base object (no changes):
```
reference:
  = 3 (Y) : 45
  = 13 (EDP) : true
  = 36 ("Active Trigger") : true
  = 1 (Object ID) : 3022
  = 350 (Rotate redirect: Mod) : 1
  = 2 (X) : 75
  = 155 : 1
```

Feel free to rename things to fit convention. For example `dist 2` for Edit Song is what the box is labelled in-game, but maybe `med dist` would be better?