### PR TITLE
Add 'duration' property to KeyframeObject

### DIFF
--- a/src/lib/schema.txt
+++ b/src/lib/schema.txt
@@ -188,6 +188,7 @@ $KeyframeRotDir = { unset cw ccw }
 $KeyframeMode = { time even dist }
 
 @KeyframeObject: Common
+duration 10 Float
 group_id 51 GroupID
 x360 537 Int
 spawn_gid 71 GroupID


### PR DESCRIPTION
I hope I did this right (if not just close this or tell me how to correct it)

Either way keyframe objects have the duration property (and I checked, its prop ID 10)

Edit: for a quick confirmation you can paste `1,3032,10,123456;` 